### PR TITLE
[FEATURE] Throw error if pdf generation fails

### DIFF
--- a/src/routes/errors.js
+++ b/src/routes/errors.js
@@ -6,8 +6,11 @@ export function unauthorized(message, req, res) {
   res.status(401).json(new Error(message));
 }
 
-export function pdfGenerationError(message, req, res) {
-  res.status(500).json(new Error(message));
+export function pdfGenerationError(message, error, res) {
+  res.status(500).json({
+    message,
+    error
+  });
 }
 
 export function needMoreInfo(message, req, res) {

--- a/src/routes/middleware.js
+++ b/src/routes/middleware.js
@@ -1,6 +1,6 @@
 import wkhtmltopdf from 'wkhtmltopdf';
 import { generateHTML, generateFileName, getBaseURL } from '../lib/util';
-import { needMoreInfo } from './errors';
+import { needMoreInfo, pdfGenerationError } from './errors';
 
 export function validate(req, res, next) {
   if (!req.body.html) {
@@ -27,9 +27,11 @@ export function generate(req, res) {
   }, function(err, stream) {
     if (err) {
       console.log('error making pdf', err);
+      pdfGenerationError('We had an issue generating your pdf file', err, res);
+    } else {
+      res.status(200).json({
+        fileLocation: getBaseURL(req) + filename
+      });
     }
-    res.status(200).json({
-      fileLocation: getBaseURL(req) + filename
-    });
   });
 }


### PR DESCRIPTION
**Summary**
If at anytime the pdf generation fails, we need the backend to respond with the error so that we can take some action on the frontend.